### PR TITLE
Add Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+  - "node"
+os: 
+  - linux
+  - osx
+  - windows
+install: npm i --force
+script: npm run build
+branches:
+  only:
+  - master
+  - develop


### PR DESCRIPTION
Adding Travis configuration file.

- Runs MySQL with a before-install hook to try and start the server.
- Isolated to just PRs and rebuilding master and develop. 
- Checking all three platforms - Linux, OSX, Windows. 
[Adding Travis config for CI testing](https://app.gitkraken.com/glo/board/XYD6yxrF9gAPmWqc/card/Xa9Wfjz-owAP0kK4)