### PR TITLE
Carousel bug - Buttons don't click through carousel

### DIFF
--- a/client/app/components/browse_articles.jsx
+++ b/client/app/components/browse_articles.jsx
@@ -78,6 +78,7 @@ class BrowseArticles extends React.Component {
                 <a
                   className="btn prev"
                   href="#carouselExampleControls"
+                  onClick={handleClick}
                   title="go back"
                   data-slide="prev"
                 >
@@ -86,6 +87,7 @@ class BrowseArticles extends React.Component {
                 <a
                   className="btn next"
                   href="#carouselExampleControls"
+                  onClick={handleClick}
                   title="more"
                   data-slide="next"
                 >
@@ -102,8 +104,7 @@ class BrowseArticles extends React.Component {
                   <div key={article.id} className="col-md-3">
                     <div className="card">
                       <div
-                        id="my-card-img-top"
-                        className="greyscale"
+                        id="my-card-img-top greyscale"
                         dangerouslySetInnerHTML={{ __html: article.photo }}
                       ></div>
 
@@ -138,7 +139,6 @@ class BrowseArticles extends React.Component {
                     <div className="card">
                       <div
                         id="my-card-img-top"
-                        className="greyscale"
                         dangerouslySetInnerHTML={{ __html: article.photo }}
                       ></div>
                       <div className="card-body">
@@ -173,3 +173,8 @@ class BrowseArticles extends React.Component {
 }
 
 export default BrowseArticles;
+
+// This function fixes the carousel not loading on start.
+function handleClick(e) {
+  e.preventDefault();
+}


### PR DESCRIPTION
The issue was that when initial loading of the software happened (with clear cache and everything), if you click on the carousel arrows, it would redirect to the href link (which references itself, carouselExampleControls), and would not move the carousel to the next items. 

The solution was to add a React event handler method to make a preventDefault() call. preventDefault is called on the event when submitting the form to prevent a browser reload/refresh. 

The bug should be fixed on all browsers now. 
