### PR TITLE
Carousel bug - add onChange to force the buttons to work

### DIFF
--- a/client/app/components/browse_articles.jsx
+++ b/client/app/components/browse_articles.jsx
@@ -83,7 +83,7 @@ class BrowseArticles extends React.Component {
                 <a
                   className="btn prev"
                   href="#carouselExampleControls"
-                  onClick={this.handleClick}
+                  onChange={this.handleClick}
                   title="go back"
                   data-slide="prev"
                 >
@@ -92,7 +92,7 @@ class BrowseArticles extends React.Component {
                 <a
                   className="btn next"
                   href="#carouselExampleControls"
-                  onClick={this.handleClick}
+                  onChange={this.handleClick}
                   title="more"
                   data-slide="next"
                 >


### PR DESCRIPTION
Hopefully this fix makes certain the carousel works. For some reason, onclick doesn't always work and you have to reload to make it work for sure.        