### PR TITLE
PWA - Add in manifest.json and service worker files

### DIFF
--- a/client/components/helpers/editor_preview.jsx
+++ b/client/components/helpers/editor_preview.jsx
@@ -1,4 +1,4 @@
-/* 
+/* --------------------------------------------------------------------------------------------------------------------------------------------
   Put all small code snippets inside the helpers folder.
   Simple editor preview, separated for easier modification
 */

--- a/client/index.html
+++ b/client/index.html
@@ -69,5 +69,14 @@
     -->
     <div id="app" class="container" />
     <script src="public/bundle.js" type="text/javascript" async></script>
+
+    <!-- Load the PWA Service Worker -->
+    <script>
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker.register("/service_worker.js");
+        });
+      }
+    </script>
   </body>
 </html>

--- a/client/manifest.json
+++ b/client/manifest.json
@@ -1,0 +1,20 @@
+{
+  "short_name": "VPIA",
+  "name" : "Virtual Platform for Indigenous Art",
+  "icons": [
+    {
+      "src": "./assets/images/logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src":"./assets/images/logo.png",
+      "sizes":"512x512",
+      "type":"image/png"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
+}

--- a/client/service_worker.js
+++ b/client/service_worker.js
@@ -1,0 +1,56 @@
+/* --------------------------------------------------------------------------------------------------------------------------------------------
+  This is the service worker file - this is where we cache the VPIA.
+*/
+importScripts(
+  "https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-sw.js"
+);
+
+if (workbox) {
+  // Serve these pages even offline (return 200 ok)
+  workbox.precaching.precacheAndRoute([
+    { url: "/" },
+    { url: "/#/landing" },
+    { url: "/#/about" },
+    { url: "/#/results" }
+  ]);
+
+  // Cache google fonts
+  workbox.routing.registerRoute(
+    /^https:\/\/fonts\.googleapis\.com/,
+    new workbox.strategies.CacheFirst({
+      cacheName: "google-fonts-stylesheets"
+    })
+  );
+
+  // Cache images
+  workbox.routing.registerRoute(
+    /\.(?:png|gif|jpg|jpeg|webp|svg)$/,
+    new workbox.strategies.NetworkFirst({
+      cacheName: "images",
+      plugins: [
+        new workbox.expiration.Plugin({
+          maxEntries: 60,
+          maxAgeSeconds: 30 * 24 * 60 * 60 // 30 Days
+        })
+      ]
+    })
+  );
+
+  //Cache css and js
+  workbox.routing.registerRoute(
+    /\.(?:js|css)$/,
+    new workbox.strategies.NetworkFirst({
+      cacheName: "static-resources"
+    })
+  );
+
+  //Cache woff and ttc
+  workbox.routing.registerRoute(
+    /\.(?:woff|ttc|otf)$/,
+    new workbox.strategies.CacheFirst({
+      cacheName: "font-resources"
+    })
+  );
+} else {
+  console.log("Workbox failed to load.");
+}

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -92,7 +92,7 @@ module.exports = {
       {
         test: cssModuleRegex,
         exclude: [/ckeditor5-[^/\\]+[/\\]theme[/\\].+\.css$/]
-      },
+      }
     ]
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1534,7 +1534,8 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.0",
@@ -1822,6 +1823,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
@@ -1831,17 +1833,20 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -1853,12 +1858,14 @@
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1866,7 +1873,8 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -1894,6 +1902,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1911,6 +1920,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1919,7 +1929,8 @@
         "core-js": {
           "version": "2.6.10",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+          "dev": true
         }
       }
     },
@@ -1927,6 +1938,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "babel-traverse": "^6.26.0",
@@ -1939,6 +1951,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
         "babel-messages": "^6.23.0",
@@ -1954,7 +1967,8 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
         }
       }
     },
@@ -1962,6 +1976,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
@@ -1972,14 +1987,16 @@
         "to-fast-properties": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
         }
       }
     },
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -3288,7 +3305,8 @@
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+      "dev": true
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -3507,6 +3525,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
       "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
+      "dev": true,
       "requires": {
         "stackframe": "^0.3.1"
       }
@@ -5077,6 +5096,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
       "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
       "requires": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
@@ -5160,6 +5180,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -5167,7 +5188,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         }
       }
     },
@@ -5897,7 +5919,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash-es": {
       "version": "4.17.15",
@@ -6155,6 +6178,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
       "requires": {
         "dom-walk": "^0.1.0"
       }
@@ -7556,7 +7580,8 @@
     "prettier": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
     },
     "private": {
       "version": "0.1.8",
@@ -7567,7 +7592,8 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -7766,7 +7792,8 @@
     "react-deep-force-update": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.1.3.tgz",
-      "integrity": "sha512-lqD4eHKVuB65RyO/hGbEST53E2/GPbcIPcFYyeW/p4vNngtH4G7jnKGlU6u1OqrFo0uNfIvwuBOg98IbLHlNEA=="
+      "integrity": "sha512-lqD4eHKVuB65RyO/hGbEST53E2/GPbcIPcFYyeW/p4vNngtH4G7jnKGlU6u1OqrFo0uNfIvwuBOg98IbLHlNEA==",
+      "dev": true
     },
     "react-dom": {
       "version": "16.12.0",
@@ -7783,6 +7810,7 @@
       "version": "3.0.0-beta.6",
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.0.0-beta.6.tgz",
       "integrity": "sha1-Rj+sC/yLY6g4UlivIMkWNqvOdfQ=",
+      "dev": true,
       "requires": {
         "babel-template": "^6.7.0",
         "global": "^4.3.0",
@@ -7796,6 +7824,7 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -7811,6 +7840,7 @@
       "version": "3.0.0-alpha.1",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
       "integrity": "sha1-RABCa8+oDKpnJMd1VpUxUgn6Swc=",
+      "dev": true,
       "requires": {
         "lodash": "^4.6.1"
       }
@@ -8072,6 +8102,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.6.0.tgz",
       "integrity": "sha512-mLjM5eYR41yOp5YKHpd3syFeGq6B4Wj5vZr64nbLvTZW5ZLff4LYk7VE4ITpVxkZpCY6OZuqh0HiP3A3uEaCpg==",
+      "dev": true,
       "requires": {
         "error-stack-parser": "^1.3.6",
         "object-assign": "^4.0.1",
@@ -8097,7 +8128,8 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -8674,6 +8706,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.11.tgz",
       "integrity": "sha512-O0pcWjJqzQFVsisPlPXuNawJHHg9N9UgpJ/aDmvi9+vnS3x1C0NhwkVFzzZ1VN0Xo+bekyweoqYvBw5ZBKiNnQ==",
+      "dev": true,
       "requires": {
         "source-map": "0.5.6"
       },
@@ -8681,7 +8714,8 @@
         "source-map": {
           "version": "0.5.6",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
         }
       }
     },
@@ -8720,7 +8754,8 @@
     "stackframe": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
-      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ="
+      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
+      "dev": true
     },
     "static-extend": {
       "version": "0.1.2",


### PR DESCRIPTION
This PR adds progressive enhancement to the VPIA by adding in Progressive Web Application files. The platform can be downloaded as a mobile or desktop application and is available offline via service workers. 

What is missing: 

- Testing on Apple ios (android works but we need to resolve the responsive design problems)
- Testing as a desktop application (firefox doesn't work and there's some contention:
See bug on mozilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1407202
See discussion on beforeinstallprompt on W3C: https://bugzilla.mozilla.org/show_bug.cgi?id=1407202#c44
- User accessibility (does the user understand that they need to refresh, there's no offline indication at the moment, modified A2HS so people understand that they're installing an actual application, etc).

<!-- You can skip this if you're fixing a typo. -->

Explain the **details** for making this change. What existing problem does the pull request solve?

- Give end users with poor internet connection the ability to reliably view the VPIA
- Gives end users the ability to download the application for later user
- Speeds up performance through caching

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

<!-- Make sure tests pass on Travis and make sure to run npm run lint and npm run prettier.. -->

[Implement Offline first architecture properly](https://app.gitkraken.com/glo/board/XYD6yxrF9gAPmWqc/card/Xd1nz-AbPwAPFgbR)