### PR TITLE
Tags support and removing photo_license from archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This platform uses a modified [Matterwiki](https://github.com/Matterwiki/Matterw
 Eslint is currently not fixing the JSX files in the app folder due to breaking changes and possible lack of backwards compatibility. We should fix this in the future but we must prioritize elsewhere.
 
 We have Travis setup for running builds in Linux, OSX and Windows. It is currently running on only the master branch.
-
+  
 ---
 
 ## Common Errors

--- a/api/articles.js
+++ b/api/articles.js
@@ -25,6 +25,7 @@ module.exports = function(app) {
       institution: req.body.institution,
       photo: req.body.photo,
       photo_license: req.body.photo_license,
+      tags: req.body.tags,
       body: req.body.body,
       topic_id: req.body.topic_id,
       user_id: req.body.user_id,
@@ -97,6 +98,7 @@ module.exports = function(app) {
             artwork_type: req.body.artwork_type,
             body: req.body.body,
             topic_id: req.body.topic_id,
+            tags: req.body.tags,
             what_changed: req.body.what_changed,
             user_id: req.body.user_id
           }
@@ -118,8 +120,8 @@ module.exports = function(app) {
           artwork_type: article[0].artwork_type,
           institution: article[0].institution,
           photo: article[0].photo,
-          photo_license: article[0].photo_license,
           body: article[0].body,
+          tags: article[0].tags,
           what_changed: article[0].what_changed,
           user_id: article[0].user_id,
           article_id: article[0].id

--- a/api/search.js
+++ b/api/search.js
@@ -32,6 +32,9 @@ module.exports = function(app) {
           },
           {
             material: { regex: SearchInput }
+          },
+          {
+            tags: { regex: SearchInput }
           }
         ]
       }

--- a/client/components/wiki/article.jsx
+++ b/client/components/wiki/article.jsx
@@ -236,6 +236,16 @@ class ViewArticle extends React.Component {
                         </li>
 
                         <li className="list-group-item">
+                          <p id="FuturaStdHeavy">Tags</p>
+                          <p
+                            id="Baskerville"
+                            dangerouslySetInnerHTML={{
+                              __html: this.state.article[0].tags
+                            }}
+                          ></p>
+                        </li>
+
+                        <li className="list-group-item">
                           <b>What Changed in last edit</b>
                           {this.state.article[0].what_changed ? (
                             <p id="Baskerville">

--- a/client/components/wiki/edit.jsx
+++ b/client/components/wiki/edit.jsx
@@ -27,6 +27,7 @@ class EditArticle extends React.Component {
       culture_group: "",
       material: "",
       artwork_type: "",
+      tags: "",
       topics: [],
       loading: true,
       isHidden: true
@@ -58,6 +59,7 @@ class EditArticle extends React.Component {
             material: response.data[0].material,
             artwork_type: response.data[0].artwork_type,
             topic_id: response.data[0].topic_id,
+            tags: response.data[0].tags,
             article: response.data
           });
         }
@@ -111,6 +113,7 @@ class EditArticle extends React.Component {
     var culture_group = this.state.culture_group;
     var material = this.state.material;
     var artwork_type = this.state.artwork_type;
+    let tags = this.state.tags;
 
     if (
       body &&
@@ -119,7 +122,8 @@ class EditArticle extends React.Component {
       what_changed &&
       culture_group &&
       material &&
-      artwork_type
+      artwork_type &&
+      tags
     ) {
       var myHeaders = new Headers({
         "Content-Type": "application/x-www-form-urlencoded",
@@ -141,6 +145,8 @@ class EditArticle extends React.Component {
           encodeURIComponent(material) +
           "&artwork_type=" +
           encodeURIComponent(artwork_type) +
+          "&tags=" +
+          encodeURIComponent(tags) +
           "&topic_id=" +
           topicId +
           "&user_id=" +
@@ -352,6 +358,29 @@ class EditArticle extends React.Component {
                                 let material = this.state.material;
                                 this.setState({
                                   material: editor.level.content
+                                });
+                              }}
+                            />
+                          </p>
+                        </li>
+
+                        <li className="list-group-item">
+                          <p id="FuturaStdHeavy">Tags</p>
+                          <p id="Baskerville">
+                            <Editor
+                              initialValue={this.state.tags}
+                              init={{
+                                inline: true,
+                                menubar: false,
+                                plugins: Config.plugins,
+                                toolbar: Config.toolbar,
+                                quickbars_insert_toolbar: false,
+                                quickbars_selection_toolbar: false
+                              }}
+                              onChange={editor => {
+                                let tags = this.state.tags;
+                                this.setState({
+                                  tags: editor.level.content
                                 });
                               }}
                             />

--- a/client/components/wiki/edit.jsx
+++ b/client/components/wiki/edit.jsx
@@ -244,7 +244,6 @@ class EditArticle extends React.Component {
                           quickbars_selection_toolbar: false
                         }}
                         onChange={editor => {
-                          let body = this.state.body;
                           this.setState({ body: editor.level.content });
                         }}
                       />
@@ -309,7 +308,6 @@ class EditArticle extends React.Component {
                                 quickbars_selection_toolbar: false
                               }}
                               onChange={editor => {
-                                let artwork_type = this.state.artwork_type;
                                 this.setState({
                                   artwork_type: editor.level.content
                                 });
@@ -332,7 +330,6 @@ class EditArticle extends React.Component {
                                 quickbars_selection_toolbar: false
                               }}
                               onChange={editor => {
-                                let culture_group = this.state.culture_group;
                                 this.setState({
                                   culture_group: editor.level.content
                                 });
@@ -355,7 +352,6 @@ class EditArticle extends React.Component {
                                 quickbars_selection_toolbar: false
                               }}
                               onChange={editor => {
-                                let material = this.state.material;
                                 this.setState({
                                   material: editor.level.content
                                 });
@@ -378,7 +374,6 @@ class EditArticle extends React.Component {
                                 quickbars_selection_toolbar: false
                               }}
                               onChange={editor => {
-                                let tags = this.state.tags;
                                 this.setState({
                                   tags: editor.level.content
                                 });

--- a/client/components/wiki/new.jsx
+++ b/client/components/wiki/new.jsx
@@ -26,6 +26,7 @@ class NewArticle extends React.Component {
       culture_group: "",
       material: "",
       artwork_type: "",
+      tags: "",
       error: "",
       loading: true
     };
@@ -68,6 +69,7 @@ class NewArticle extends React.Component {
     var photo = this.state.photo;
     var institution = this.state.institution;
     var photo_license = this.state.photo_license;
+    let tags = this.state.tags;
 
     if (
       body &&
@@ -78,7 +80,8 @@ class NewArticle extends React.Component {
       artwork_type &&
       institution &&
       photo &&
-      photo_license
+      photo_license &&
+      tags
     ) {
       var myHeaders = new Headers({
         "Content-Type": "application/x-www-form-urlencoded",
@@ -101,6 +104,8 @@ class NewArticle extends React.Component {
           encodeURIComponent(artwork_type) +
           "&photo=" +
           encodeURIComponent(photo) +
+          "&tags=" +
+          encodeURIComponent(tags) +
           "&institution=" +
           encodeURIComponent(institution) +
           "&photo_license=" +
@@ -341,6 +346,29 @@ class NewArticle extends React.Component {
                           <p id="Baskerville">
                             <Editor
                               initialValue="<i>e.g. argilite, silver, etc.</i>"
+                              init={{
+                                inline: true,
+                                menubar: false,
+                                plugins: Config.plugins,
+                                toolbar: Config.toolbar,
+                                quickbars_insert_toolbar: false,
+                                quickbars_selection_toolbar: false
+                              }}
+                              onChange={editor => {
+                                let material = this.state.material;
+                                this.setState({
+                                  material: editor.level.content
+                                });
+                              }}
+                            />
+                          </p>
+                        </li>
+
+                        <li className="list-group-item">
+                          <p id="FuturaStdHeavy">Tags</p>
+                          <p id="Baskerville">
+                            <Editor
+                              initialValue=""
                               init={{
                                 inline: true,
                                 menubar: false,

--- a/client/components/wiki/new.jsx
+++ b/client/components/wiki/new.jsx
@@ -208,7 +208,6 @@ class NewArticle extends React.Component {
                           quickbars_selection_toolbar: false
                         }}
                         onChange={editor => {
-                          let body = this.state.body;
                           this.setState({ body: editor.level.content });
                         }}
                       />
@@ -237,7 +236,6 @@ class NewArticle extends React.Component {
                             toolbar: "image | help"
                           }}
                           onChange={editor => {
-                            let photo = this.state.photo;
                             this.setState({ photo: editor.level.content });
                           }}
                         />
@@ -258,7 +256,6 @@ class NewArticle extends React.Component {
                                 quickbars_selection_toolbar: false
                               }}
                               onChange={editor => {
-                                let photo_license = this.state.photo_license;
                                 this.setState({
                                   photo_license: editor.level.content
                                 });
@@ -286,7 +283,6 @@ class NewArticle extends React.Component {
                                 quickbars_selection_toolbar: false
                               }}
                               onChange={editor => {
-                                let institution = this.state.insitution;
                                 this.setState({
                                   institution: editor.level.content
                                 });
@@ -309,7 +305,6 @@ class NewArticle extends React.Component {
                                 quickbars_selection_toolbar: false
                               }}
                               onChange={editor => {
-                                let artwork_type = this.state.artwork_type;
                                 this.setState({
                                   artwork_type: editor.level.content
                                 });
@@ -332,7 +327,6 @@ class NewArticle extends React.Component {
                                 quickbars_selection_toolbar: false
                               }}
                               onChange={editor => {
-                                let culture_group = this.state.culture_group;
                                 this.setState({
                                   culture_group: editor.level.content
                                 });
@@ -355,7 +349,6 @@ class NewArticle extends React.Component {
                                 quickbars_selection_toolbar: false
                               }}
                               onChange={editor => {
-                                let material = this.state.material;
                                 this.setState({
                                   material: editor.level.content
                                 });
@@ -378,9 +371,8 @@ class NewArticle extends React.Component {
                                 quickbars_selection_toolbar: false
                               }}
                               onChange={editor => {
-                                let material = this.state.material;
                                 this.setState({
-                                  material: editor.level.content
+                                  tags: editor.level.content
                                 });
                               }}
                             />

--- a/client/components/wiki/simple_article.jsx
+++ b/client/components/wiki/simple_article.jsx
@@ -69,14 +69,6 @@ class SimpleArticle extends React.Component {
                 ></div>
               </div>
               <div className="single-article-meta">
-                License:
-                <div
-                  dangerouslySetInnerHTML={{
-                    __html: this.state.article[0].photo_license
-                  }}
-                ></div>
-              </div>
-              <div className="single-article-meta">
                 Type:{" "}
                 <div
                   dangerouslySetInnerHTML={{
@@ -97,6 +89,14 @@ class SimpleArticle extends React.Component {
                 <div
                   dangerouslySetInnerHTML={{
                     __html: this.state.article[0].culture_group
+                  }}
+                ></div>
+              </div>
+              <div className="single-article-meta">
+                Tags:{" "}
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: this.state.article[0].tags
                   }}
                 ></div>
               </div>

--- a/models/archive.js
+++ b/models/archive.js
@@ -13,7 +13,7 @@ var Archive = schema.define("archive", {
   institution: { type: schema.String, limit: 255 },
   material: { type: schema.String },
   artwork_type: { type: schema.String, limit: 255 },
-  photo_license: { type: schema.String, limit: 500 },
+  tags: { type: schema.String },
   body: { type: schema.Text },
   updated_at: { type: schema.Date, default: Date.now },
   what_changed: { type: schema.String, limit: 255 }

--- a/models/article.js
+++ b/models/article.js
@@ -14,6 +14,7 @@ var Article = schema.define("article", {
   material: { type: schema.String },
   artwork_type: { type: schema.String, limit: 255 },
   photo_license: { type: schema.Text },
+  tags: { type: schema.String },
   body: { type: schema.Text },
   created_at: { type: schema.Date, default: Date.now },
   updated_at: { type: schema.Date, default: Date.now },


### PR DESCRIPTION
This PR gives an extra article variable of tags so that users can add in relevant tags that they think the artworks should have.

This pr also removes erroneous photo license from history.
[Remove license from view history](https://app.gitkraken.com/glo/board/XYD6yxrF9gAPmWqc/card/XeV1sPAbPwAPFuGc)
[Tags for article](https://app.gitkraken.com/glo/board/XYD6yxrF9gAPmWqc/card/XjiIWxhLpwAQLekH)