### PR TITLE
MediaService - fixed uploaded images with datestamps and extensions

### DIFF
--- a/MainContainer/client/components/main/app.jsx
+++ b/MainContainer/client/components/main/app.jsx
@@ -60,7 +60,7 @@ class App extends React.Component {
             className="alert alert-secondary alert-dismissible fade show"
             role="alert"
           >
-            Testing if Modified react is updated - meaning that the design and
+            This platform is currently in Alpha - meaning that the design and
             features are subject to change. If you identify any major bugs or
             would like to comment on the platform's functionality, please{" "}
             <a href="mailto:vpia@ocadu.ca">send us an email.</a>

--- a/MediaService/server.js
+++ b/MediaService/server.js
@@ -1,6 +1,5 @@
 const express = require("express");
 const multer = require("multer");
-const upload = multer({ dest: __dirname + "/upload" });
 const path = require("path");
 let cors = require("cors");
 require("dotenv").config({ path: "../.env" });
@@ -14,6 +13,17 @@ const httpsOptions = {
 };
 
 const app = express();
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, "./upload");
+  },
+  filename: (req, file, cb) => {
+    cb(null, Date.now() + "-" + file.originalname);
+  }
+});
+
+const upload = multer({ storage: storage });
 
 app.use(cors());
 app.use(express.static("upload"));

--- a/WikiService/client/components/new.jsx
+++ b/WikiService/client/components/new.jsx
@@ -129,11 +129,14 @@ class NewArticle extends React.Component {
             <div className="card">
               <div className="my-card-img-top">
                 <Editor
+                  id="mainPhoto"
                   initialValue='<img src="../../assets/images/logo.png">'
                   init={{
                     inline: true,
                     menubar: false,
                     images_upload_url: process.env.IMAGEUPLOAD,
+                    a11y_advanced_options: true,
+                    images_reuse_filename: true,
                     plugins: ["image"],
                     toolbar: "image | help"
                   }}
@@ -277,6 +280,7 @@ class NewArticle extends React.Component {
                       <hr />
                       <div id="article-photo" className="single-article-body">
                         <Editor
+                          id="mainEditor"
                           initialValue=""
                           init={{
                             inline: false,
@@ -286,7 +290,11 @@ class NewArticle extends React.Component {
                             plugins: Config.plugins,
                             toolbar: Config.toolbar,
                             quickbars_insert_toolbar: false,
-                            quickbars_selection_toolbar: false
+                            quickbars_selection_toolbar: false,
+                            a11y_advanced_options: true,
+                            image_caption: true,
+                            images_reuse_filename: true,
+                            paste_data_images: true
                           }}
                           onChange={editor => {
                             this.setState({ body: editor.level.content });


### PR DESCRIPTION
This PR:
- Fixes the randomly generated names of files with no extensions with a datestamped + filename + file extension combination so users can open the image in a new tab.
- Removed the AWS test sentence from the main alert box
- Added a11 and a few other options for usability purposes in the wysiwygs.
