### PR TITLE
Edit Archive/Institution Record Feature

### DIFF
--- a/HistoryService/api/archives.js
+++ b/HistoryService/api/archives.js
@@ -157,4 +157,38 @@ module.exports = app => {
       }
     }
   );
+  /* --------------------------------------------------------------------------------------------------------------------------------------------
+  PUT /articles/:id/history - Edit the oldest archive/or Institution record
+*/
+  app.put("/articles/:id/history", isAdminAuthenticated, async (req, res) => {
+    try {
+      const institution = Archives.update(
+        {
+          where: {
+            what_changed: "Original Museum Record",
+            article_id: req.params.id
+          }
+        },
+        {
+          title: req.body.title,
+          body: req.body.body
+        }
+      );
+      res.json({
+        error: {
+          error: false
+        },
+        data: institution
+      });
+    } catch (err) {
+      res.status(500).json({
+        error: {
+          message:
+            "PUT: /articles/:id/history (error updating institution record) " +
+            err.message
+        },
+        data: {}
+      });
+    }
+  });
 };

--- a/HistoryService/client/components/institution.jsx
+++ b/HistoryService/client/components/institution.jsx
@@ -6,11 +6,25 @@ import { Link } from "react-router";
 import Loader from "./helpers/loader.jsx";
 import InfoBox from "../../../WikiService/client/components/infobox.jsx";
 import StatusAlert, { StatusAlertService } from "react-status-alert";
+// Import Editor configurations - change general behaviour in the json, specific changes should be done in new.jsx and edit.jsx
+import Config from "../../config/editor.json";
+// TinyMCE Editor import
+import { Editor } from "@tinymce/tinymce-react";
 
 class Institution extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { article: {}, archives: {}, loading: true };
+    this.toggleEdit = this.toggleEdit.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.onInputChange = this.onInputChange.bind(this);
+    this.state = {
+      article: {},
+      archives: {},
+      title: "",
+      body: "",
+      edit: true,
+      loading: true
+    };
   }
 
   /* --------------------------------------------------------------------------------------------------------------------------------------------
@@ -55,10 +69,60 @@ class Institution extends React.Component {
     }
   }
 
+  toggleEdit() {
+    this.setState({ edit: !this.state.edit });
+  }
+
+  onInputChange(event) {
+    this.setState({
+      [event.target.name]: event.target.value
+    });
+  }
+
+  async handleSubmit(e) {
+    e.preventDefault();
+    let record = {
+      title: encodeURIComponent(this.state.title),
+      body: encodeURIComponent(this.state.body)
+    };
+
+    let headers = new Headers({
+      "Content-Type": "application/x-www-form-urlencoded",
+      "x-access-token": window.localStorage.getItem("userToken")
+    });
+
+    let that = this;
+
+    let request = {
+      method: "PUT",
+      headers: headers,
+      body:
+        "article_id=" +
+        that.props.params.articleId +
+        "&title=" +
+        record.title +
+        "&body=" +
+        record.body
+    };
+
+    let institution_url =
+      `${process.env.HISTORYSERVICE}/api/articles/` +
+      that.props.params.articleId +
+      "/history";
+
+    const res = await fetch(institution_url, request);
+    const json = await res.json();
+    if (json.error.error) {
+      StatusAlertService.showError(json.error.message);
+    } else {
+      StatusAlertService.showSuccess("Institution Record Updated Successfully");
+      this.setState({ edit: true });
+    }
+  }
+
   // --------------------------------------------------------------------------------------------------------------------------------------------
   // Renders the institution page.
   render() {
-    let user_name = "";
     let article = [],
       archive = [];
     if (this.state.loading) return <Loader />;
@@ -137,17 +201,79 @@ class Institution extends React.Component {
               </div>
             </div>
             <div class="tab-bar-card">
+              {window.localStorage.getItem("admin") === "1" ? (
+                <button
+                  className="btn btn-text float-right"
+                  type="button"
+                  aria-label="Edit Institution Record"
+                  onClick={this.toggleEdit}
+                >
+                  {this.state.edit ? (
+                    <i className="fa fa-edit"></i>
+                  ) : (
+                    <i className="fa fa-pencil"></i>
+                  )}
+                </button>
+              ) : (
+                ""
+              )}
               <div className="article-heading">
-                <h1 className="single-article-title">
-                  {archive.title}- {archive.institution} Record
-                </h1>
-
-                <div
-                  className="single-article-body"
-                  dangerouslySetInnerHTML={{
-                    __html: archive.body
-                  }}
-                ></div>
+                {this.state.edit ? (
+                  <h1 className="single-article-title">
+                    {archive.title}- {archive.institution} Record
+                  </h1>
+                ) : (
+                  <h1 className="single-article-title">
+                    <input
+                      name="title"
+                      value={this.state.title}
+                      onChange={this.onInputChange}
+                      className="form-control"
+                      placeholder="Change Institution title"
+                    />
+                    - {archive.institution} Record
+                  </h1>
+                )}
+                {this.state.edit ? (
+                  <div
+                    className="single-article-body"
+                    type={this.state.edit ? "password" : "text"}
+                    dangerouslySetInnerHTML={{
+                      __html: archive.body
+                    }}
+                  ></div>
+                ) : (
+                  <Editor
+                    initialValue={archive.body}
+                    init={{
+                      inline: false,
+                      menubar: false,
+                      automatic_uploads: true,
+                      images_upload_url: process.env.IMAGEUPLOAD,
+                      plugins: Config.plugins,
+                      toolbar: Config.toolbar,
+                      quickbars_insert_toolbar: false,
+                      quickbars_selection_toolbar: false,
+                      a11y_advanced_options: true,
+                      image_caption: true,
+                      images_reuse_filename: true,
+                      paste_data_images: true
+                    }}
+                    onChange={editor => {
+                      this.setState({ body: editor.level.content });
+                    }}
+                  />
+                )}
+                {this.state.edit ? (
+                  ""
+                ) : (
+                  <button
+                    className="btn btn-default btn-block btn-lg"
+                    onClick={this.handleSubmit}
+                  >
+                    Update Institution Record
+                  </button>
+                )}
               </div>
             </div>
           </div>

--- a/HistoryService/client/components/institution.jsx
+++ b/HistoryService/client/components/institution.jsx
@@ -4,88 +4,54 @@
 import React from "react";
 import { Link } from "react-router";
 import Loader from "./helpers/loader.jsx";
-import BrowseArchives from "./browse_archives.jsx";
 import InfoBox from "../../../WikiService/client/components/infobox.jsx";
 import StatusAlert, { StatusAlertService } from "react-status-alert";
 
 class Institution extends React.Component {
   constructor(props) {
     super(props);
-    this.deleteArticle = this.deleteArticle.bind(this);
-    this.state = { article: {}, user: {}, archives: {}, loading: true };
+    this.state = { article: {}, archives: {}, loading: true };
   }
 
   /* --------------------------------------------------------------------------------------------------------------------------------------------
   On initial load, GET ONE Article from Article API and GET archives history
 */
-  componentDidMount() {
-    let myHeaders = new Headers({
+  async componentDidMount() {
+    let headers = new Headers({
       "Content-Type": "application/x-www-form-urlencoded",
       "x-access-token": window.localStorage.getItem("userToken")
     });
 
-    let myInit = { method: "GET", headers: myHeaders };
+    let request = { method: "GET", headers: headers };
     let that = this;
+
     let article_url =
       `${process.env.HISTORYSERVICE}/api/articles/` +
       that.props.params.articleId +
       "/history";
     let archives_url = "/api/articles/" + that.props.params.articleId;
 
-    Promise.all([fetch(archives_url, myInit), fetch(article_url, myInit)])
-      .then(function(responses) {
-        return Promise.all(
-          responses.map(function(response) {
-            return response.json();
-          })
-        );
+    let response = await Promise.all([
+      fetch(archives_url, request),
+      fetch(article_url, request)
+    ]);
+    let json = await Promise.all(
+      response.map(result => {
+        return result.json();
       })
-      .then(function(data) {
-        const article = data[0];
-        const archives = data[1];
-        that.setState({
-          article: article.data,
-          archives: archives.data,
-          loading: false
-        });
-      })
-
-      .catch(function(error) {
-        StatusAlertService.showError(response.error.message);
+    );
+    const article = json[0];
+    const archives = json[1];
+    if (article.error.error) {
+      StatusAlertService.showError(article.error.message);
+    } else if (archives.error.error) {
+      StatusAlertService.showError(archives.error.message);
+    } else {
+      that.setState({
+        article: article.data,
+        archives: archives.data,
+        loading: false
       });
-  }
-  /* --------------------------------------------------------------------------------------------------------------------------------------------
-  deleteArticle() - takes id, sends Delete request to Article and redirects
-  user back to home.
-*/
-  deleteArticle(e) {
-    e.preventDefault();
-    let del = confirm("Are you sure you want to delete this article?");
-
-    if (del) {
-      let myHeaders = new Headers({
-        "Content-Type": "application/x-www-form-urlencoded",
-        "x-access-token": window.localStorage.getItem("userToken")
-      });
-
-      let myInit = {
-        method: "DELETE",
-        headers: myHeaders,
-        body: "id=" + this.state.article[0].id
-      };
-
-      fetch("/api/articles/", myInit)
-        .then(function(response) {
-          return response.json();
-        })
-        .then(function(response) {
-          if (response.error.error) {
-            StatusAlertService.showError(response.error.message);
-          } else {
-            StatusAlertService.showSuccess("Article has been deleted");
-            hashHistory.push("home");
-          }
-        });
     }
   }
 
@@ -93,27 +59,31 @@ class Institution extends React.Component {
   // Renders the institution page.
   render() {
     let user_name = "";
-    let article = [];
+    let article = [],
+      archive = [];
     if (this.state.loading) return <Loader />;
-    else if (this.state.article[0]) {
+    else if (
+      this.state.article[0] &&
+      this.state.archives[this.state.archives.length - 1]
+    ) {
       article = this.state.article[0];
+      archive = this.state.archives[this.state.archives.length - 1];
     }
     return (
       <div className="container-fluid">
         <StatusAlert />
         <div className="row">
           <InfoBox
-            photo={article.photo}
-            photo_license={article.photo_license}
-            user_name={user_name}
-            institution={article.institution}
-            artwork_type={article.artwork_type}
-            culture_group={article.culture_group}
-            material={article.material}
-            tags={article.tags}
-            what_changed={article.what_changed}
-            delete={this.deleteArticle}
+            photo={archive.photo}
+            photo_license={archive.photo_license}
+            institution={archive.institution}
+            artwork_type={archive.artwork_type}
+            culture_group={archive.culture_group}
+            material={archive.material}
+            tags={archive.tags}
+            what_changed={archive.what_changed}
             display={false}
+            displayDelete={false}
           />
           <div className="col-md-6 tabBar-content">
             <div className="tabBar row justify-content-between align-items-end">
@@ -169,14 +139,13 @@ class Institution extends React.Component {
             <div class="tab-bar-card">
               <div className="article-heading">
                 <h1 className="single-article-title">
-                  {article.title}- {article.institution} Record
+                  {archive.title}- {archive.institution} Record
                 </h1>
 
                 <div
                   className="single-article-body"
                   dangerouslySetInnerHTML={{
-                    __html: this.state.archives[this.state.archives.length - 1]
-                      .body
+                    __html: archive.body
                   }}
                 ></div>
               </div>

--- a/HistoryService/config/editor.json
+++ b/HistoryService/config/editor.json
@@ -1,0 +1,4 @@
+{
+  "plugins": "advlist autolink autoresize lists image link charmap print preview anchor searchreplace visualblocks code fullscreen insertdatetime media table code help wordcount powerpaste quickbars",
+  "toolbar": "bold italic underline | image quicktable | alignleft aligncenter alignright | bullist numlist outdent indent | undo redo | charmap | help"
+}

--- a/MainContainer/client/components/routes.jsx
+++ b/MainContainer/client/components/routes.jsx
@@ -15,7 +15,6 @@ import Login from "../../../UserService/client/components/login.jsx";
 import Article from "../../../WikiService/client/components/article.jsx";
 import NewArticle from "../../../WikiService/client/components/new.jsx";
 import EditArticle from "../../../WikiService/client/components/edit.jsx";
-import InfoBox from "../../../WikiService/client/components/infobox.jsx";
 import ArticleHistory from "../../../HistoryService/client/components/history.jsx";
 import Institution from "../../../HistoryService/client/components/institution.jsx";
 import Search from "../../../SearchService/client/components/search.jsx";

--- a/WikiService/client/components/article.jsx
+++ b/WikiService/client/components/article.jsx
@@ -152,7 +152,8 @@ class ViewArticle extends React.Component {
               tags={article.tags}
               what_changed={article.what_changed}
               delete={this.deleteArticle}
-              display={true}
+              displayUser={true}
+              displayDelete={true}
             />
 
             <div className="col-md-6 tabBar-content">

--- a/WikiService/client/components/infobox.jsx
+++ b/WikiService/client/components/infobox.jsx
@@ -9,7 +9,8 @@ import StatusAlert, { StatusAlertService } from "react-status-alert";
 
 class InfoBox extends React.Component {
   render() {
-    const display = this.props.display;
+    const displayUser = this.props.displayUser;
+    const displayDelete = this.props.displayDelete;
     return (
       <div className="col-md-3 article-info-box">
         <div className="card">
@@ -29,7 +30,7 @@ class InfoBox extends React.Component {
           </div>
 
           <ul className="list-group list-group-flush">
-            {display ? (
+            {displayUser ? (
               <li className="list-group-item">
                 <h6>Last Updated By</h6>
                 <p>{this.props.user_name}</p>
@@ -88,7 +89,7 @@ class InfoBox extends React.Component {
             </li>
           </ul>
 
-          {window.localStorage.getItem("admin") === "1" ? (
+          {displayDelete && window.localStorage.getItem("admin") === "1" ? (
             <button
               className="btn btn-primary btn-block"
               onClick={this.props.delete}


### PR DESCRIPTION
This PR adds the requested Institution record editing feature.

- Added endpoint for articles/:id/history, assuming that there will be no other reason to edit Archives.
- Updated InfoBox to selectively display delete button and username as well as removed it from the routes. Adjusted Article.jsx to use the new options as well as institution.jsx. 
> I suggest we alter the colouration of the infobox and the institution record so that end users don't get confused what data belongs to which. We should move to make sure the institution page pulls only from the original record. If we leave the infobox as it is, it looks as if it's the same as the article even though the `updated by` variable was removed.
- Institution.jsx now pulls variables from the archive as opposed to the article. Refactored to use async/await and removed unused variables.
- There is now an edit button only visible to Admins on the institution page. The button toggles and changes to edit mode, which toggles input fields for title and body as well as a button to submit changes. Once updated, the institution record returns to regular viewing. Removed more unused variables (username) and imported TinyMCE for the institution body editing. 
[Edit the institution record - Michael, because insitution records change](https://app.gitkraken.com/glo/card/9c8b44a3011c412ea8fc8d86bfe4347c)