### PR TITLE
npm run dev - fixing the fs issue

### DIFF
--- a/MainContainer/config/webpack.config.js
+++ b/MainContainer/config/webpack.config.js
@@ -57,6 +57,9 @@ module.exports = {
     contentBase: BUILD_DIR,
     publicPath: "/public/"
   },
+  node: {
+    fs: 'empty'
+  },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new Dotenv({

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@babel/core": "^7.13.1",
         "@babel/plugin-proposal-class-properties": "^7.13.0",
         "@babel/plugin-transform-runtime": "^7.12.10",
-        "@babel/preset-env": "^7.13.5",
+        "@babel/preset-env": "^7.13.10",
         "@babel/preset-react": "^7.12.13",
         "babel-loader": "^8.2.2",
         "compression": "^1.7.4",
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.13.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.6.tgz",
-      "integrity": "sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==",
+      "version": "7.13.11",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.11.tgz",
+      "integrity": "sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==",
       "dev": true
     },
     "node_modules/@babel/core": {
@@ -126,15 +126,27 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
-      "integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
+      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.13.0",
+        "@babel/compat-data": "^7.13.8",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
-        "semver": "7.0.0"
+        "semver": "^6.3.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
@@ -383,14 +395,17 @@
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.13.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.5.tgz",
-      "integrity": "sha512-8cErJEDzhZgNKzYyjCKsHuyPqtWxG8gc9h4OFSUDJu0vCAOsObPU2LcECnW0kJwh/b+uUz46lObVzIXw0fzAbA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
+      "integrity": "sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-remap-async-to-generator": "^7.13.0",
-        "@babel/plugin-syntax-async-generators": "^7.8.0"
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
@@ -404,13 +419,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-dynamic-import": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.17.tgz",
-      "integrity": "sha512-ZNGoFZqrnuy9H2izB2jLlnNDAfVPlGl5NhFEiFe4D84ix9GQGygF+CWMGHKuE+bpyS/AOuDQCnkiRNqW2IzS1Q==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.13.8.tgz",
+      "integrity": "sha512-ONWKj0H6+wIRCkZi9zSbZtE/r73uOhMVHh256ys0UzfM7I3d4n+spZNWjOnJv2gzopumP2Wxi186vI8N0Y2JyQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-export-namespace-from": {
@@ -424,33 +442,42 @@
       }
     },
     "node_modules/@babel/plugin-proposal-json-strings": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.13.tgz",
-      "integrity": "sha512-v9eEi4GiORDg8x+Dmi5r8ibOe0VXoKDeNPYcTTxdGN4eOWikrJfDJCJrr1l5gKGvsNyGJbrfMftC2dTL6oz7pg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-json-strings": "^7.8.0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.13.tgz",
-      "integrity": "sha512-fqmiD3Lz7jVdK6kabeSr1PZlWSUVqSitmHEe3Z00dtGTKieWnX9beafvavc32kjORa5Bai4QNHgFDwWJP+WtSQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.0.tgz",
-      "integrity": "sha512-UkAvFA/9+lBBL015gjA68NvKiCReNxqFLm3SdNKaM3XXoDisA7tMAIX4PmIwatFoFqMxxT3WyG9sK3MO0Kting==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.13.8.tgz",
+      "integrity": "sha512-w4zOPKUFPX1mgvTmL/fcEqy34hrQ1CRcGxdphBc6snDnnqJ47EZDIyop6IwXzAC8G916hsIuXB2ZMBCExC5k7Q==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+        "@babel/plugin-syntax-json-strings": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.13.8.tgz",
+      "integrity": "sha512-aul6znYB4N4HGweImqKn59Su9RS8lbUIqxtXTOcAGtNIDczoEFv+l1EhmX8rUBp3G1jMjKJm8m0jXVp63ZpS4A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.8.tgz",
+      "integrity": "sha512-iePlDPBn//UhxExyS9KyeYU7RM9WScAG+D3Hhno0PLJebAEpDZMocbDe64eqynhNAnwz/vZoL/q/QB2T1OH39A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-numeric-separator": {
@@ -464,35 +491,46 @@
       }
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.0.tgz",
-      "integrity": "sha512-B4qphdSTp0nLsWcuei07JPKeZej4+Hd22MdnulJXQa1nCcGSBlk8FiqenGERaPZ+PuYhz4Li2Wjc8yfJvHgUMw==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz",
+      "integrity": "sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==",
       "dev": true,
       "dependencies": {
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-compilation-targets": "^7.13.8",
         "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-transform-parameters": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.13.tgz",
-      "integrity": "sha512-9+MIm6msl9sHWg58NvqpNpLtuFbmpFYk37x8kgnGzAHvX35E1FyAwSUt5hIkSoWJFSAH+iwU8bJ4fcD1zKXOzg==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.13.8.tgz",
+      "integrity": "sha512-0wS/4DUF1CuTmGo+NiaHfHcVSeSLj5S3e6RivPTg/2k3wOv3jO35tZ6/ZWsQhQMvdgI7CwphjQa/ccarLymHVA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.0.tgz",
-      "integrity": "sha512-OVRQOZEBP2luZrvEbNSX5FfWDousthhdEoAOpej+Tpe58HFLvqRClT89RauIvBuCDFEip7GW1eT86/5lMy2RNA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.8.tgz",
+      "integrity": "sha512-hpbBwbTgd7Cz1QryvwJZRo1U0k1q8uyBmeXOSQUjdg/A2TASkhR/rz7AyqZ/kS8kbpsNA80rOYbxySBJAqmhhQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-private-methods": {
@@ -525,6 +563,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
@@ -543,6 +584,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-export-namespace-from": {
@@ -561,6 +605,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
@@ -579,6 +626,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -588,6 +638,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
@@ -606,6 +659,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
@@ -615,6 +671,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
@@ -624,6 +683,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
@@ -784,28 +846,34 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.0.tgz",
-      "integrity": "sha512-j7397PkIB4lcn25U2dClK6VLC6pr2s3q+wbE8R3vJvY6U1UTBBj0n6F+5v6+Fd/UwfDPAorMOs2TV+T4M+owpQ==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.8.tgz",
+      "integrity": "sha512-9QiOx4MEGglfYZ4XOnU79OHr6vIWUakIj9b4mioN8eQIoEh+pf5p/zEB36JpDFWA12nNMiRf7bfoRvl9Rn79Bw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.13.0",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-simple-access": "^7.12.13",
         "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.13.tgz",
-      "integrity": "sha512-aHfVjhZ8QekaNF/5aNdStCGzwTbU7SI5hUybBKlMzqIMC7w7Ho8hx5a4R/DkTHfRfLwHGGxSpFt9BfxKCoXKoA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.13.8.tgz",
+      "integrity": "sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-hoist-variables": "^7.12.13",
-        "@babel/helper-module-transforms": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-hoist-variables": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-identifier": "^7.12.11",
         "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
@@ -853,6 +921,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
@@ -1003,39 +1074,39 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.13.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.5.tgz",
-      "integrity": "sha512-xUeKBIIcbwxGevyWMSWZOW98W1lp7toITvVsMxSddCEQy932yYiF4fCB+CG3E/MXzFX3KbefgvCqEQ7TDoE6UQ==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.10.tgz",
+      "integrity": "sha512-nOsTScuoRghRtUsRr/c69d042ysfPHcu+KOB4A9aAO9eJYqrkat+LF8G1yp1HD18QiwixT2CisZTr/0b3YZPXQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.13.5",
-        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-compilation-targets": "^7.13.10",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-option": "^7.12.17",
-        "@babel/plugin-proposal-async-generator-functions": "^7.13.5",
+        "@babel/plugin-proposal-async-generator-functions": "^7.13.8",
         "@babel/plugin-proposal-class-properties": "^7.13.0",
-        "@babel/plugin-proposal-dynamic-import": "^7.12.17",
+        "@babel/plugin-proposal-dynamic-import": "^7.13.8",
         "@babel/plugin-proposal-export-namespace-from": "^7.12.13",
-        "@babel/plugin-proposal-json-strings": "^7.12.13",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.12.13",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.0",
+        "@babel/plugin-proposal-json-strings": "^7.13.8",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.13.8",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
         "@babel/plugin-proposal-numeric-separator": "^7.12.13",
-        "@babel/plugin-proposal-object-rest-spread": "^7.13.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.12.13",
-        "@babel/plugin-proposal-optional-chaining": "^7.13.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.13.8",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.8",
         "@babel/plugin-proposal-private-methods": "^7.13.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
-        "@babel/plugin-syntax-async-generators": "^7.8.0",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-        "@babel/plugin-syntax-json-strings": "^7.8.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-top-level-await": "^7.12.13",
         "@babel/plugin-transform-arrow-functions": "^7.13.0",
         "@babel/plugin-transform-async-to-generator": "^7.13.0",
@@ -1052,8 +1123,8 @@
         "@babel/plugin-transform-literals": "^7.12.13",
         "@babel/plugin-transform-member-expression-literals": "^7.12.13",
         "@babel/plugin-transform-modules-amd": "^7.13.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.13.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.12.13",
+        "@babel/plugin-transform-modules-commonjs": "^7.13.8",
+        "@babel/plugin-transform-modules-systemjs": "^7.13.8",
         "@babel/plugin-transform-modules-umd": "^7.13.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.12.13",
         "@babel/plugin-transform-new-target": "^7.12.13",
@@ -1069,13 +1140,25 @@
         "@babel/plugin-transform-typeof-symbol": "^7.12.13",
         "@babel/plugin-transform-unicode-escapes": "^7.12.13",
         "@babel/plugin-transform-unicode-regex": "^7.12.13",
-        "@babel/preset-modules": "^0.1.3",
+        "@babel/preset-modules": "^0.1.4",
         "@babel/types": "^7.13.0",
         "babel-plugin-polyfill-corejs2": "^0.1.4",
         "babel-plugin-polyfill-corejs3": "^0.1.3",
         "babel-plugin-polyfill-regenerator": "^0.1.2",
         "core-js-compat": "^3.9.0",
-        "semver": "7.0.0"
+        "semver": "^6.3.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/preset-modules": {
@@ -9530,9 +9613,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.6.tgz",
-      "integrity": "sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==",
+      "version": "7.13.11",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.11.tgz",
+      "integrity": "sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==",
       "dev": true
     },
     "@babel/core": {
@@ -9590,15 +9673,23 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
-      "integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
+      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.0",
+        "@babel/compat-data": "^7.13.8",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
-        "semver": "7.0.0"
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-create-class-features-plugin": {
@@ -9840,14 +9931,14 @@
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.13.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.5.tgz",
-      "integrity": "sha512-8cErJEDzhZgNKzYyjCKsHuyPqtWxG8gc9h4OFSUDJu0vCAOsObPU2LcECnW0kJwh/b+uUz46lObVzIXw0fzAbA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
+      "integrity": "sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-remap-async-to-generator": "^7.13.0",
-        "@babel/plugin-syntax-async-generators": "^7.8.0"
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
       }
     },
     "@babel/plugin-proposal-class-properties": {
@@ -9861,13 +9952,13 @@
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.17.tgz",
-      "integrity": "sha512-ZNGoFZqrnuy9H2izB2jLlnNDAfVPlGl5NhFEiFe4D84ix9GQGygF+CWMGHKuE+bpyS/AOuDQCnkiRNqW2IzS1Q==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.13.8.tgz",
+      "integrity": "sha512-ONWKj0H6+wIRCkZi9zSbZtE/r73uOhMVHh256ys0UzfM7I3d4n+spZNWjOnJv2gzopumP2Wxi186vI8N0Y2JyQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-export-namespace-from": {
@@ -9881,33 +9972,33 @@
       }
     },
     "@babel/plugin-proposal-json-strings": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.13.tgz",
-      "integrity": "sha512-v9eEi4GiORDg8x+Dmi5r8ibOe0VXoKDeNPYcTTxdGN4eOWikrJfDJCJrr1l5gKGvsNyGJbrfMftC2dTL6oz7pg==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.13.8.tgz",
+      "integrity": "sha512-w4zOPKUFPX1mgvTmL/fcEqy34hrQ1CRcGxdphBc6snDnnqJ47EZDIyop6IwXzAC8G916hsIuXB2ZMBCExC5k7Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-json-strings": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.13.tgz",
-      "integrity": "sha512-fqmiD3Lz7jVdK6kabeSr1PZlWSUVqSitmHEe3Z00dtGTKieWnX9beafvavc32kjORa5Bai4QNHgFDwWJP+WtSQ==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.13.8.tgz",
+      "integrity": "sha512-aul6znYB4N4HGweImqKn59Su9RS8lbUIqxtXTOcAGtNIDczoEFv+l1EhmX8rUBp3G1jMjKJm8m0jXVp63ZpS4A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
       }
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.0.tgz",
-      "integrity": "sha512-UkAvFA/9+lBBL015gjA68NvKiCReNxqFLm3SdNKaM3XXoDisA7tMAIX4PmIwatFoFqMxxT3WyG9sK3MO0Kting==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.8.tgz",
+      "integrity": "sha512-iePlDPBn//UhxExyS9KyeYU7RM9WScAG+D3Hhno0PLJebAEpDZMocbDe64eqynhNAnwz/vZoL/q/QB2T1OH39A==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-numeric-separator": {
@@ -9921,35 +10012,37 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.0.tgz",
-      "integrity": "sha512-B4qphdSTp0nLsWcuei07JPKeZej4+Hd22MdnulJXQa1nCcGSBlk8FiqenGERaPZ+PuYhz4Li2Wjc8yfJvHgUMw==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz",
+      "integrity": "sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==",
       "dev": true,
       "requires": {
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-compilation-targets": "^7.13.8",
         "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-transform-parameters": "^7.13.0"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.13.tgz",
-      "integrity": "sha512-9+MIm6msl9sHWg58NvqpNpLtuFbmpFYk37x8kgnGzAHvX35E1FyAwSUt5hIkSoWJFSAH+iwU8bJ4fcD1zKXOzg==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.13.8.tgz",
+      "integrity": "sha512-0wS/4DUF1CuTmGo+NiaHfHcVSeSLj5S3e6RivPTg/2k3wOv3jO35tZ6/ZWsQhQMvdgI7CwphjQa/ccarLymHVA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.0.tgz",
-      "integrity": "sha512-OVRQOZEBP2luZrvEbNSX5FfWDousthhdEoAOpej+Tpe58HFLvqRClT89RauIvBuCDFEip7GW1eT86/5lMy2RNA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.8.tgz",
+      "integrity": "sha512-hpbBwbTgd7Cz1QryvwJZRo1U0k1q8uyBmeXOSQUjdg/A2TASkhR/rz7AyqZ/kS8kbpsNA80rOYbxySBJAqmhhQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-private-methods": {
@@ -10238,9 +10331,9 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.0.tgz",
-      "integrity": "sha512-j7397PkIB4lcn25U2dClK6VLC6pr2s3q+wbE8R3vJvY6U1UTBBj0n6F+5v6+Fd/UwfDPAorMOs2TV+T4M+owpQ==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.8.tgz",
+      "integrity": "sha512-9QiOx4MEGglfYZ4XOnU79OHr6vIWUakIj9b4mioN8eQIoEh+pf5p/zEB36JpDFWA12nNMiRf7bfoRvl9Rn79Bw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.13.0",
@@ -10250,14 +10343,14 @@
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.13.tgz",
-      "integrity": "sha512-aHfVjhZ8QekaNF/5aNdStCGzwTbU7SI5hUybBKlMzqIMC7w7Ho8hx5a4R/DkTHfRfLwHGGxSpFt9BfxKCoXKoA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.13.8.tgz",
+      "integrity": "sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.12.13",
-        "@babel/helper-module-transforms": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-hoist-variables": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-identifier": "^7.12.11",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
@@ -10457,39 +10550,39 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.13.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.5.tgz",
-      "integrity": "sha512-xUeKBIIcbwxGevyWMSWZOW98W1lp7toITvVsMxSddCEQy932yYiF4fCB+CG3E/MXzFX3KbefgvCqEQ7TDoE6UQ==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.10.tgz",
+      "integrity": "sha512-nOsTScuoRghRtUsRr/c69d042ysfPHcu+KOB4A9aAO9eJYqrkat+LF8G1yp1HD18QiwixT2CisZTr/0b3YZPXQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.5",
-        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-compilation-targets": "^7.13.10",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-option": "^7.12.17",
-        "@babel/plugin-proposal-async-generator-functions": "^7.13.5",
+        "@babel/plugin-proposal-async-generator-functions": "^7.13.8",
         "@babel/plugin-proposal-class-properties": "^7.13.0",
-        "@babel/plugin-proposal-dynamic-import": "^7.12.17",
+        "@babel/plugin-proposal-dynamic-import": "^7.13.8",
         "@babel/plugin-proposal-export-namespace-from": "^7.12.13",
-        "@babel/plugin-proposal-json-strings": "^7.12.13",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.12.13",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.0",
+        "@babel/plugin-proposal-json-strings": "^7.13.8",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.13.8",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
         "@babel/plugin-proposal-numeric-separator": "^7.12.13",
-        "@babel/plugin-proposal-object-rest-spread": "^7.13.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.12.13",
-        "@babel/plugin-proposal-optional-chaining": "^7.13.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.13.8",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.8",
         "@babel/plugin-proposal-private-methods": "^7.13.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
-        "@babel/plugin-syntax-async-generators": "^7.8.0",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-        "@babel/plugin-syntax-json-strings": "^7.8.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-top-level-await": "^7.12.13",
         "@babel/plugin-transform-arrow-functions": "^7.13.0",
         "@babel/plugin-transform-async-to-generator": "^7.13.0",
@@ -10506,8 +10599,8 @@
         "@babel/plugin-transform-literals": "^7.12.13",
         "@babel/plugin-transform-member-expression-literals": "^7.12.13",
         "@babel/plugin-transform-modules-amd": "^7.13.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.13.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.12.13",
+        "@babel/plugin-transform-modules-commonjs": "^7.13.8",
+        "@babel/plugin-transform-modules-systemjs": "^7.13.8",
         "@babel/plugin-transform-modules-umd": "^7.13.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.12.13",
         "@babel/plugin-transform-new-target": "^7.12.13",
@@ -10523,13 +10616,21 @@
         "@babel/plugin-transform-typeof-symbol": "^7.12.13",
         "@babel/plugin-transform-unicode-escapes": "^7.12.13",
         "@babel/plugin-transform-unicode-regex": "^7.12.13",
-        "@babel/preset-modules": "^0.1.3",
+        "@babel/preset-modules": "^0.1.4",
         "@babel/types": "^7.13.0",
         "babel-plugin-polyfill-corejs2": "^0.1.4",
         "babel-plugin-polyfill-corejs3": "^0.1.3",
         "babel-plugin-polyfill-regenerator": "^0.1.2",
         "core-js-compat": "^3.9.0",
-        "semver": "7.0.0"
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "@babel/preset-modules": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.13.1",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/plugin-transform-runtime": "^7.12.10",
-    "@babel/preset-env": "^7.13.5",
+    "@babel/preset-env": "^7.13.10",
     "@babel/preset-react": "^7.12.13",
     "babel-loader": "^8.2.2",
     "compression": "^1.7.4",


### PR DESCRIPTION
`npm run dev` needs to be greatly refactored - the npm scripts are getting too large. 

In the meantime, the command is partially fixed - adding fs empty and ensuring dangling node processes were not interfering with the platform fixed the problem.