### PR TITLE
Wiki - fixed image upload issue

### DIFF
--- a/WikiService/client/components/new.jsx
+++ b/WikiService/client/components/new.jsx
@@ -41,10 +41,14 @@ class NewArticle extends React.Component {
       [event.target.name]: event.target.value
     });
   }
+
   // --------------------------------------------------------------------------------------------------------------------------------------------
   // Take variables from admin input and create a new Article object and send POST
   async handleSubmit(e) {
-    e.preventDefault();
+    this.state.imageEditor.target.editorUpload.uploadImages();
+    this.state.imageEditorBody.target.editorUpload.uploadImages();
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
     let record = {
       body: encodeURIComponent(this.state.body),
       title: encodeURIComponent(this.state.title),
@@ -175,10 +179,15 @@ class NewArticle extends React.Component {
                     a11y_advanced_options: true,
                     images_reuse_filename: true,
                     plugins: ["image"],
-                    toolbar: "image | help"
+                    toolbar: "image | help",
+                    automatic_uploads: false,
+                    images_dataimg_filter: function(img) {
+                      return !img.hasAttribute("internal-blob");
+                    }
                   }}
                   onChange={editor => {
                     this.setState({ photo: editor.level.content });
+                    this.setState({ imageEditor: editor });
                   }}
                 />
               </div>
@@ -331,10 +340,15 @@ class NewArticle extends React.Component {
                             a11y_advanced_options: true,
                             image_caption: true,
                             images_reuse_filename: true,
-                            paste_data_images: true
+                            paste_data_images: true,
+                            automatic_uploads: false,
+                            images_dataimg_filter: function(img) {
+                              return !img.hasAttribute("internal-blob");
+                            }
                           }}
                           onChange={editor => {
                             this.setState({ body: editor.level.content });
+                            this.setState({ imageEditorBody: editor });
                           }}
                         />
                       </div>

--- a/WikiService/client/components/new.jsx
+++ b/WikiService/client/components/new.jsx
@@ -45,6 +45,7 @@ class NewArticle extends React.Component {
   // --------------------------------------------------------------------------------------------------------------------------------------------
   // Take variables from admin input and create a new Article object and send POST
   async handleSubmit(e) {
+    e.preventDefault();
     this.state.imageEditor.target.editorUpload.uploadImages();
     this.state.imageEditorBody.target.editorUpload.uploadImages();
     await new Promise(resolve => setTimeout(resolve, 1000));
@@ -331,7 +332,6 @@ class NewArticle extends React.Component {
                           init={{
                             inline: false,
                             menubar: false,
-                            automatic_uploads: true,
                             images_upload_url: process.env.IMAGEUPLOAD,
                             plugins: Config.plugins,
                             toolbar: Config.toolbar,

--- a/WikiService/client/components/new.jsx
+++ b/WikiService/client/components/new.jsx
@@ -46,10 +46,9 @@ class NewArticle extends React.Component {
   // Take variables from admin input and create a new Article object and send POST
   async handleSubmit(e) {
     e.preventDefault();
-    this.state.imageEditor.target.editorUpload.uploadImages();
-    this.state.imageEditorBody.target.editorUpload.uploadImages();
-    await new Promise(resolve => setTimeout(resolve, 1000));
-
+    const mainImageUpload = this.state.imageEditor.target.editorUpload.uploadImages();
+    const bodyImageUpload = this.state.imageEditorBody.target.editorUpload.uploadImages();
+    await Promise.all([mainImageUpload, bodyImageUpload]);
     let record = {
       body: encodeURIComponent(this.state.body),
       title: encodeURIComponent(this.state.title),


### PR DESCRIPTION
This PR fixed the Media Upload issue, it now only upload the image when the admin user clicks on "Create Article". Both the main photo and photos in the article body are fixed now.

I haven't done it on the normal user end, because the `handleSubmit` in "edit" component is not an `async` function. Once we got that fixed, I will finish that too.


[If you upload an image, it is immediately uploaded even if you change it](https://app.gitkraken.com/glo/card/3c929aa539114abe8a60aa841e167f7a)