### PR TITLE
Public user - only show edit buttons to logged in users

### DIFF
--- a/HistoryService/client/components/history.jsx
+++ b/HistoryService/client/components/history.jsx
@@ -59,13 +59,17 @@ class ArticleHistory extends React.Component {
                   >
                     Edit History
                   </Link>
-                  <Link
-                    to={"/article/edit/" + this.props.params.articleId}
-                    className="none-deco tabBar-tab yellow-tab"
-                    aria-label="Edit tab, go to edit the article"
-                  >
-                    Edit
-                  </Link>
+                  {window.localStorage.getItem("userToken") ? (
+                    <Link
+                      to={"/article/edit/" + this.props.params.articleId}
+                      className="none-deco tabBar-tab yellow-tab"
+                      aria-label="Edit tab, go to edit the article"
+                    >
+                      Edit
+                    </Link>
+                  ) : (
+                    ""
+                  )}
                   <Link
                     to={"/article/institution/" + this.props.params.articleId}
                     className="bottom-align-text tabBar-tab darkgrey-tab"

--- a/HistoryService/client/components/institution.jsx
+++ b/HistoryService/client/components/institution.jsx
@@ -177,13 +177,17 @@ class Institution extends React.Component {
                 >
                   Edit History
                 </Link>
-                <Link
-                  to={"/article/edit/" + article.id}
-                  className="none-deco tabBar-tab yellow-tab"
-                  aria-label="Edit tab, go to edit the article"
-                >
-                  Edit
-                </Link>
+                {window.localStorage.getItem("userToken") ? (
+                  <Link
+                    to={"/article/edit/" + article.id}
+                    className="none-deco tabBar-tab yellow-tab"
+                    aria-label="Edit tab, go to edit the article"
+                  >
+                    Edit
+                  </Link>
+                ) : (
+                  ""
+                )}
                 <Link
                   to={"/article/institution/" + article.id}
                   className="bottom-align-text tabBar-tab darkgrey-tab is-active"

--- a/WikiService/client/components/article.jsx
+++ b/WikiService/client/components/article.jsx
@@ -184,13 +184,17 @@ class ViewArticle extends React.Component {
                   >
                     Edit History
                   </Link>
-                  <Link
-                    to={"/article/edit/" + article.id}
-                    className="none-deco tabBar-tab yellow-tab"
-                    aria-label="Edit tab, go to edit the article"
-                  >
-                    Edit
-                  </Link>
+                  {window.localStorage.getItem("userToken") ? (
+                    <Link
+                      to={"/article/edit/" + article.id}
+                      className="none-deco tabBar-tab yellow-tab"
+                      aria-label="Edit tab, go to edit the article"
+                    >
+                      Edit
+                    </Link>
+                  ) : (
+                    ""
+                  )}
                   <Link
                     to={"/article/institution/" + article.id}
                     className="bottom-align-text tabBar-tab darkgrey-tab"

--- a/WikiService/client/components/edit.jsx
+++ b/WikiService/client/components/edit.jsx
@@ -377,13 +377,17 @@ class EditArticle extends React.Component {
                   >
                     Edit History
                   </Link>
-                  <Link
-                    to={"/article/edit/" + this.state.article[0].id}
-                    className="none-deco tabBar-tab yellow-tab is-active"
-                    aria-label="Edit tab, go to edit the article"
-                  >
-                    Edit
-                  </Link>
+                  {window.localStorage.getItem("userToken") ? (
+                    <Link
+                      to={"/article/edit/" + this.state.article[0].id}
+                      className="none-deco tabBar-tab yellow-tab is-active"
+                      aria-label="Edit tab, go to edit the article"
+                    >
+                      Edit
+                    </Link>
+                  ) : (
+                    ""
+                  )}
                   <Link
                     to={"/article/institution/" + this.state.article[0].id}
                     className="bottom-align-text tabBar-tab darkgrey-tab"


### PR DESCRIPTION
This PR adds a check to the edit buttons to only show up if the user is logged in/has a token. 

[Ensure public cannot see routes such as edit page](https://app.gitkraken.com/glo/card/17424044d56d4311b184ccc131d4062e)